### PR TITLE
Remove-unused-materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,35 @@
 # Selections To Objects
+
 ##### Cinema 4D Python Plugin
 
 ![Selections To Object Icon](https://3.bp.blogspot.com/-ldXQ2BSFV8M/Xn4udU72loI/AAAAAAAACe4/5jtp9pKhZXYRGTHJQRNmtAUuuGzsXH7-gCKgBGAsYHg/s1600/selections2objects256.png "Icon")
 
 Convert all polygon selection tags into separate objects
 
-For more informations please visit : https://safina3d.blogspot.com
+For more informations please visit : <https://safina3d.blogspot.com>
 
-#### Installation: 
+#### Installation
+
 Clone the project or download the zip file and extract it into the Maxon plugins directory.
 
 - Windows: `C:\Program Files\MAXON\CINEMA 4D R<version>\plugins\`
 - MacOS: `/Applications/MAXON/CINEMA 4D R1<version>/plugins/`
 
 ### How to use
+
 - Select your polygon object
 - Make sure that your object has at least one **polygon selection tag**
 - Click on the "Selections To Objects" icon to run the plugin
 
-### Additional commands:
+### Additional commands
+
 - ALT Button: Make the generated objects children of the original object
 - CTRL Button: Delete the original object
 
 ### ChangeLog
-- V1.1
+
+- v1.2.0
+  - [Feat] Unused materials removed from split and source objects
+- v1.1.0
   - [Fix] Incorrect children hierarchy
   - [Feat] Selection tag removed from source object

--- a/SelectionToObject/selection2object.pyp
+++ b/SelectionToObject/selection2object.pyp
@@ -4,6 +4,7 @@
   Author  : Safina3D
   Version : 1.2.0
   Website : https://safina3d.blogspot.com
+  Description: Convert polygon selection tags into separate objects.
 """
 
 import os
@@ -12,27 +13,48 @@ from c4d import gui, utils, bitmaps, BaseContainer
 
 
 def call_split_command(obj, doc):
-    result = utils.SendModelingCommand(command=c4d.MCOMMAND_SPLIT,
-                                    list=[obj.GetClone(flags=c4d.COPYFLAGS_NO_HIERARCHY|c4d.COPYFLAGS_NO_BITS)],
-                                    mode=c4d.MODELINGCOMMANDMODE_POLYGONSELECTION,
-                                    bc=BaseContainer(),
-                                    doc=doc)
-    return result[0] if result else None
+    """Splits an object based on the active polygon selection."""
+    if obj is None or doc is None:
+        return None
+
+    try:
+        result = utils.SendModelingCommand(
+            command=c4d.MCOMMAND_SPLIT,
+            list=[obj.GetClone(flags=c4d.COPYFLAGS_NO_HIERARCHY | c4d.COPYFLAGS_NO_BITS)],
+            mode=c4d.MODELINGCOMMANDMODE_POLYGONSELECTION,
+            bc=BaseContainer(),
+            doc=doc
+        )
+        return result[0] if result else None
+
+    except Exception as e:
+        print(f"Error in split command: {e}")
+        return None
 
 
-def check_button(button):
-    msg = BaseContainer()
-    gui.GetInputState(c4d.BFM_INPUT_KEYBOARD, c4d.BFM_INPUT_CHANNEL, msg)
-    return msg.GetLong(c4d.BFM_INPUT_QUALIFIER) & button
+def is_button_pressed(button):
+    """Checks if a specific button is pressed."""
+    try:
+        msg = BaseContainer()
+        gui.GetInputState(c4d.BFM_INPUT_KEYBOARD, c4d.BFM_INPUT_CHANNEL, msg)
+        return msg.GetLong(c4d.BFM_INPUT_QUALIFIER) & button
+    except:
+        return False
 
 
 def remove_selection_tags(obj):
+    """Removes all polygon selection tags from an object."""
+    if obj is None:
+        return
+
     tags = obj.GetTags()
     for tag in tags:
         if c4d.Tpolygonselection == tag.GetType():
             tag.Remove()
 
-def remove_unused_materials_from_split_obj(obj, selection_name):
+
+def remove_unused_materials(obj, selection_name):
+    """Handles unused materials and clears restrictions."""
     if obj is None:
         return
 
@@ -40,79 +62,112 @@ def remove_unused_materials_from_split_obj(obj, selection_name):
     for tag in tags:
         if tag.GetType() != c4d.Ttexture:
             continue
-        
-        restriction_name = tag[c4d.TEXTURETAG_RESTRICTION]
 
-        if restriction_name == selection_name:
-            # Erase restriction as we've already split the object
-            tag[c4d.TEXTURETAG_RESTRICTION] = ""
-        elif restriction_name != "":
+        texture_restriction_name = tag[c4d.TEXTURETAG_RESTRICTION]
+
+        if selection_name is None and texture_restriction_name == "":
+            continue
+
+        # Has a restriction but we're not targeting any selection
+        has_unmatched_restriction = selection_name is None and texture_restriction_name != ""
+        # Has a restriction that doesn't match our target selection
+        has_mismatching_selection = selection_name and texture_restriction_name != selection_name
+
+        if has_unmatched_restriction or has_mismatching_selection:
             tag.Remove()
+        else:
+            # The restriction matches the selection
+            tag[c4d.TEXTURETAG_RESTRICTION] = ""
+
 
 class SelectionsToObjects(c4d.plugins.CommandData):
 
     def GetState(self, doc):
+        """Enables the command if the active object is a polygon object."""
         op = doc.GetActiveObject()
         return c4d.CMD_ENABLED if op and op.IsInstanceOf(c4d.Opolygon) else False
 
     def Execute(self, doc):
+        """Converts polygon selection tags into separate objects."""
+        if doc is None:
+            return False
 
         original_obj = doc.GetActiveObject()
+        if not original_obj or not original_obj.IsInstanceOf(c4d.Opolygon):
+            return False
 
-        delete_obj = check_button(c4d.QCTRL)
-        make_child = check_button(c4d.QSHIFT)
+        delete_original_obj = is_button_pressed(c4d.QCTRL)
+        make_child_objects = is_button_pressed(c4d.QSHIFT)
 
         poly_selection = original_obj.GetPolygonS()
+        if not poly_selection:
+            return False
+
         count = original_obj.GetPolygonCount()
-        tags = reversed(original_obj.GetTags())
+        if count == 0:
+            return False
+
+        tags = list(reversed(original_obj.GetTags()))
         new_obj_count = 0
+
+        doc.StartUndo()
         doc.AddUndo(c4d.UNDOTYPE_CHANGE, original_obj)
 
-        for tag in tags:
-            if c4d.Tpolygonselection == tag.GetType():
-                poly_selection.DeselectAll()
-                bs = tag.GetBaseSelect()
+        try:
+            for tag in tags:
+                if c4d.Tpolygonselection == tag.GetType():
+                    poly_selection.DeselectAll()
+                    bs = tag.GetBaseSelect()
 
-                # Empty selection case
-                if bs.GetCount() == 0:
-                    continue
+                    if bs is None or bs.GetCount() == 0:
+                        continue
 
-                for i in range(count):
-                    if bs.IsSelected(i):
-                        poly_selection.Select(i)
+                    for i in range(count):
+                        if bs.IsSelected(i):
+                            poly_selection.Select(i)
 
-                split_obj = call_split_command(original_obj, doc)
-                if split_obj:
-                    selection_name = tag.GetName()
-                    split_obj.SetName(selection_name)
-                    utils.SendModelingCommand(command=c4d.MCOMMAND_DELETE,
-                                              list=[original_obj],
-                                              mode=c4d.MODELINGCOMMANDMODE_POLYGONSELECTION,
-                                              doc=doc)
-                    
-                    remove_selection_tags(split_obj)
-                    remove_unused_materials(obj=split_obj, selection_name=selection_name)
-                    
-                    if make_child:_from_split_obj
-                        doc.InsertObject(split_obj, parent=original_obj)
-                    else:
-                        doc.InsertObject(split_obj, parent=None, pred=original_obj)
+                    split_obj = call_split_command(original_obj, doc)
+                    if split_obj:
+                        selection_name = tag.GetName()
+                        split_obj.SetName(selection_name)
 
-                    doc.AddUndo(c4d.UNDOTYPE_NEW, split_obj)
-                    new_obj_count += 1
+                        # Delete selected polygons from original
+                        utils.SendModelingCommand(
+                            command=c4d.MCOMMAND_DELETE,
+                            list=[original_obj],
+                            mode=c4d.MODELINGCOMMANDMODE_POLYGONSELECTION,
+                            doc=doc
+                        )
 
-                tag.Remove()
+                        remove_selection_tags(split_obj)
+                        remove_unused_materials(obj=split_obj, selection_name=selection_name)
 
-        # Original object is typically covered with redundant materials
-        remove_unused_materials(obj=original_obj, selection_name=None)
+                        # Insert new object in hierarchy
+                        if make_child_objects and original_obj:
+                            doc.InsertObject(split_obj, parent=original_obj)
+                        else:
+                            doc.InsertObject(split_obj, parent=None, pred=original_obj)
 
-        if delete_obj and not make_child and new_obj_count > 0:
-            original_obj.Remove()
+                        doc.AddUndo(c4d.UNDOTYPE_NEW, split_obj)
+                        new_obj_count += 1
 
-        doc.EndUndo()
-        c4d.EventAdd()
+                    tag.Remove()
+
+            remove_unused_materials(obj=original_obj, selection_name=None)
+
+            if delete_original_obj  and not make_child_objects and new_obj_count > 0 and original_obj:
+                original_obj.Remove()
+
+        except Exception as e:
+            print(f"Error during execution: {e}")
+            doc.DoUndo()
+            return False
+
+        finally:
+            doc.EndUndo()
+            c4d.EventAdd()
+
         return True
-
 
 if __name__ == '__main__':
     icon_absolute_path = os.path.join(os.path.dirname(__file__), 'res/icons', 'selection.tif')


### PR DESCRIPTION
I've added support for the automatic removal of unused Material Tags so that the Split & Source Objects are now much cleaner.

"Unused" = Restricted to another selection than the one in this split.

Unrestricted materials are preserved.

Restriction names were also removed from the texture tags as they don't point to anything.